### PR TITLE
Fix recognition of pointers to strings

### DIFF
--- a/src/gen/common/util.lisp
+++ b/src/gen/common/util.lisp
@@ -113,7 +113,7 @@
            (%enveloped-entity ()
              (claw.spec:unqualify-foreign-entity (claw.spec:foreign-enveloped-entity entity)))
            (%enveloped-char-p ()
-             (let ((unwrapped (claw.spec:unwrap-foreign-entity entity)))
+             (let ((unwrapped (claw.spec:unwrap-foreign-entity-1 entity)))
                (and (typep unwrapped 'claw.spec:foreign-primitive)
                     (string= "char" (claw.spec:foreign-entity-name unwrapped)))))
            (%lisp-name ()

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -107,6 +107,7 @@
            #:*tag-types*
            #:format-foreign-entity-c-name
 
+           #:unwrap-foreign-entity-1
            #:unwrap-foreign-entity
            #:unalias-foreign-entity
            #:unqualify-foreign-entity))
@@ -699,11 +700,19 @@
   (format-default-c-name (format-full-foreign-entity-name this) const-qualified name))
 
 
-(defun unwrap-foreign-entity (entity)
+(defun unwrap-foreign-entity-1 (entity)
   (loop for current = entity then (foreign-enveloped-entity current)
-        while (foreign-envelope-p current)
-        finally (return current)))
+        count (typep current 'foreign-pointer) into pointer-depth of-type fixnum
+        when (> pointer-depth 1)
+          return current
+        unless (foreign-envelope-p current)
+          return current))
 
+(defun unwrap-foreign-entity (entity)
+  (loop for current = entity then unwrapped
+        for unwrapped = (unwrap-foreign-entity-1 current)
+        when (eq current unwrapped)
+          return current))
 
 (defun unqualify-foreign-entity (entity)
   (loop for current = entity then (foreign-enveloped-entity current)


### PR DESCRIPTION
This PR makes `char**` recognized as `(:pointer :string)` instead of just `:string`.