### PR TITLE
Append ref qualifier to signed-as type on 'this'

### DIFF
--- a/src/gen/common/generator/function.lisp
+++ b/src/gen/common/generator/function.lisp
@@ -1,7 +1,5 @@
 (cl:in-package :claw.generator.common)
 
-(alexandria:define-constant this-parameter-entity-name "__claw_this_" :test #'string=)
-
 (defvar *adapt-mode* :c)
 
 (defgeneric adapt-type (entity)
@@ -211,7 +209,7 @@
                                 (not (claw.spec:foreign-method-static-p entity)))
                            (list* (make-instance
                                    'claw.spec:foreign-parameter
-                                   :name this-parameter-entity-name
+                                   :name "__claw_this_"
                                    :enveloped (make-instance 'claw.spec:foreign-pointer
                                                              :enveloped (claw.spec:foreign-owner entity)))
                                   params)

--- a/src/gen/common/generator/function.lisp
+++ b/src/gen/common/generator/function.lisp
@@ -150,6 +150,12 @@
                             (format nil "~A(~{~A~^, ~})"
                                     (claw.spec:format-full-foreign-entity-name entity)
                                     param-names))
+                           ;; For rvalue-qualified methods, be careful to generate an rvalue;
+                           ;; this is occasionally needed for overload disambiguation.
+                           ((eq (claw.spec:foreign-method-ref-qualifier entity) :rvalue)
+                            (format nil "std::move(*__claw_this_).~A(~{~A~^, ~})"
+                                    name
+                                    param-names))
                            (t
                             (format nil "__claw_this_->~A(~{~A~^, ~})"
                                     name

--- a/src/gen/common/generator/function.lisp
+++ b/src/gen/common/generator/function.lisp
@@ -213,12 +213,22 @@
                                adapted-params))
                (params (if (and (typep entity 'claw.spec:foreign-method)
                                 (not (claw.spec:foreign-method-static-p entity)))
-                           (list* (make-instance
-                                   'claw.spec:foreign-parameter
-                                   :name "__claw_this_"
-                                   :enveloped (make-instance 'claw.spec:foreign-pointer
-                                                             :enveloped (claw.spec:foreign-owner entity)))
-                                  params)
+                           (let* ((owner (claw.spec:foreign-owner entity))
+                                  ;; Constness of `this' occasionally matters for
+                                  ;; overload resolution.
+                                  (target-type
+                                    (if (claw.spec:foreign-method-const-p entity)
+                                        (make-instance 'claw.spec:foreign-const-qualifier
+                                                       :enveloped owner)
+                                        owner))
+                                  (this-type
+                                    (make-instance 'claw.spec:foreign-pointer
+                                                   :enveloped target-type)))
+                             (list* (make-instance
+                                      'claw.spec:foreign-parameter
+                                      :name "__claw_this_"
+                                      :enveloped this-type)
+                                    params))
                            params))
                (params (if (and result-type-adapted-from
                                 (not (typep result-type-adapted-from 'claw.spec:foreign-reference)))

--- a/src/gen/common/generator/function.lisp
+++ b/src/gen/common/generator/function.lisp
@@ -1,5 +1,6 @@
 (cl:in-package :claw.generator.common)
 
+(alexandria:define-constant this-parameter-entity-name "__claw_this_" :test #'string=)
 
 (defvar *adapt-mode* :c)
 
@@ -210,7 +211,7 @@
                                 (not (claw.spec:foreign-method-static-p entity)))
                            (list* (make-instance
                                    'claw.spec:foreign-parameter
-                                   :name "__claw_this_"
+                                   :name this-parameter-entity-name
                                    :enveloped (make-instance 'claw.spec:foreign-pointer
                                                              :enveloped (claw.spec:foreign-owner entity)))
                                   params)

--- a/src/gen/common/packages.lisp
+++ b/src/gen/common/packages.lisp
@@ -27,7 +27,6 @@
            #:adapted-function-result-type
            #:adapted-function-body
            #:adapted-function-entity
-           #:this-parameter-entity-name
 
            #:adapt-type
 

--- a/src/gen/common/packages.lisp
+++ b/src/gen/common/packages.lisp
@@ -27,6 +27,7 @@
            #:adapted-function-result-type
            #:adapted-function-body
            #:adapted-function-entity
+           #:this-parameter-entity-name
 
            #:adapt-type
 

--- a/src/gen/iffi/cxx/generator/function.lisp
+++ b/src/gen/iffi/cxx/generator/function.lisp
@@ -42,11 +42,19 @@
         for iffi-type = (when from
                           (entity->iffi-type
                            (claw.spec:foreign-enveloped-entity from)))
+        for ref-qual = (and (string= (claw.spec:foreign-entity-name param)
+                                     this-parameter-entity-name)
+                            (let ((rq (claw.spec:foreign-method-ref-qualifier
+                                       (adapted-function-entity adapted-function))))
+                              (and (not (eq rq ':none)) rq)))
         collect `(,name ,cffi-type
                         ,@(unless (and (equal cffi-type cffi-type-no-override)
                                        (or (null iffi-type)
-                                           (equal cffi-type iffi-type)))
-                            (list :signed-as (or iffi-type cffi-type-no-override))))))
+                                           (equal cffi-type iffi-type))
+                                       (null ref-qual))
+                            (list :signed-as
+                                  (append (ensure-cons (or iffi-type cffi-type-no-override))
+                                          (and ref-qual (list ref-qual))))))))
 
 
 (defun generate-function-binding (entity)

--- a/src/gen/iffi/cxx/generator/function.lisp
+++ b/src/gen/iffi/cxx/generator/function.lisp
@@ -43,7 +43,7 @@
                           (entity->iffi-type
                            (claw.spec:foreign-enveloped-entity from)))
         for ref-qual = (and (string= (claw.spec:foreign-entity-name param)
-                                     this-parameter-entity-name)
+                                     "__claw_this_")
                             (let ((rq (claw.spec:foreign-method-ref-qualifier
                                        (adapted-function-entity adapted-function))))
                               (and (not (eq rq ':none)) rq)))

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -718,6 +718,7 @@
                              :variadic (%resect:function-proto-variadic-p method-prototype)
                              :static (%resect:type-method-static-p type-method)
                              :const (%resect:type-method-const-p type-method)
+                             :ref-qualifier (%resect:method-ref-qualifier method-decl)
                              :template (if (cffi:null-pointer-p method-decl)
                                            nil
                                            (%resect:declaration-template-p method-decl)))

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -673,57 +673,58 @@
                            (%resect:function-proto-result-type method-prototype)
                            (parse-type-by-category
                             (%resect:function-proto-result-type method-prototype)))))
-        (multiple-value-bind (method newp)
-            (register-entity 'foreign-method
-                             :id (%resect:type-method-id type-method)
-                             :kind (cond
-                                     (constructor-p
-                                      :constructor)
-                                     ((starts-with #\~ pure-method-name)
-                                      :destructor)
-                                     ((starts-with-subseq "operator" pure-method-name)
-                                      :operator)
-                                     (t :regular))
-                             :source (if (cffi:null-pointer-p method-decl)
-                                         (%resect:type-method-source type-method)
+        (unless (%resect:method-deleted-p method-decl)
+          (multiple-value-bind (method newp)
+              (register-entity 'foreign-method
+                               :id (%resect:type-method-id type-method)
+                               :kind (cond
+                                       (constructor-p
+                                        :constructor)
+                                       ((starts-with #\~ pure-method-name)
+                                        :destructor)
+                                       ((starts-with-subseq "operator" pure-method-name)
+                                        :operator)
+                                       (t :regular))
+                               :source (if (cffi:null-pointer-p method-decl)
+                                           (%resect:type-method-source type-method)
                                          (%resect:declaration-source method-decl))
-                             :name (cond
-                                     (constructor-p
-                                      (string+ pure-method-name
-                                               (extract-template-argument-string
-                                                (%resect:type-name record-type))))
-                                     ((cast-operator-p pure-method-name
-                                                       result-type)
-                                      (string+ "operator "
-                                               (foreign-entity-name result-type)))
+                               :name (cond
+                                       (constructor-p
+                                        (string+ pure-method-name
+                                                 (extract-template-argument-string
+                                                   (%resect:type-name record-type))))
+                                       ((cast-operator-p pure-method-name
+                                                         result-type)
+                                        (string+ "operator "
+                                                 (foreign-entity-name result-type)))
 
-                                     (t (%resect:type-method-name type-method)))
-                             :owner entity
-                             :namespace (unless-empty
-                                         (if (cffi:null-pointer-p method-decl)
-                                             (claw.spec:foreign-entity-namespace entity)
-                                             (%resect:declaration-namespace method-decl)))
-                             :mangled mangled-name
-                             :location (if (cffi:null-pointer-p method-decl)
-                                           (make-instance 'foreign-location
-                                                          :path ""
-                                                          :line 0
-                                                          :column 0)
+                                       (t (%resect:type-method-name type-method)))
+                               :owner entity
+                               :namespace (unless-empty
+                                            (if (cffi:null-pointer-p method-decl)
+                                                (claw.spec:foreign-entity-namespace entity)
+                                              (%resect:declaration-namespace method-decl)))
+                               :mangled mangled-name
+                               :location (if (cffi:null-pointer-p method-decl)
+                                             (make-instance 'foreign-location
+                                                            :path ""
+                                                            :line 0
+                                                            :column 0)
                                            (make-declaration-location method-decl))
-                             :result-type result-type
-                             :parameters (parse-instantiated-method-parameters
-                                          (%resect:function-proto-parameters method-prototype)
-                                          (unless (cffi:null-pointer-p method-decl)
-                                            (%resect:method-parameters method-decl)))
-                             :variadic (%resect:function-proto-variadic-p method-prototype)
-                             :static (%resect:type-method-static-p type-method)
-                             :const (%resect:type-method-const-p type-method)
-                             :ref-qualifier (%resect:method-ref-qualifier method-decl)
-                             :template (if (cffi:null-pointer-p method-decl)
-                                           nil
+                               :result-type result-type
+                               :parameters (parse-instantiated-method-parameters
+                                             (%resect:function-proto-parameters method-prototype)
+                                             (unless (cffi:null-pointer-p method-decl)
+                                               (%resect:method-parameters method-decl)))
+                               :variadic (%resect:function-proto-variadic-p method-prototype)
+                               :static (%resect:type-method-static-p type-method)
+                               :const (%resect:type-method-const-p type-method)
+                               :ref-qualifier (%resect:method-ref-qualifier method-decl)
+                               :template (if (cffi:null-pointer-p method-decl)
+                                             nil
                                            (%resect:declaration-template-p method-decl)))
-          (when newp
-            (setf (gethash mangled-name *mangled-table*) method)))))))
+            (when newp
+              (setf (gethash mangled-name *mangled-table*) method))))))))
 
 
 (defun method-exists-p (decl)

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -80,6 +80,7 @@
            #:foreign-method-static-p
            #:foreign-method-const-p
            #:foreign-method-deleted-p
+           #:foreign-method-ref-qualifier
 
            #:foreign-variable
            #:foreing-variable-type
@@ -477,7 +478,10 @@
             :reader foreign-method-const-p)
    (deleted-p :initarg :deleted
               :initform nil
-              :reader foreign-method-deleted-p)))
+              :reader foreign-method-deleted-p)
+   (ref-qualifier :initarg :ref-qualifier
+                  :initform nil
+                  :reader foreign-method-ref-qualifier)))
 
 
 ;;;

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -476,9 +476,6 @@
    (const-p :initarg :const
              :initform nil
             :reader foreign-method-const-p)
-   (deleted-p :initarg :deleted
-              :initform nil
-              :reader foreign-method-deleted-p)
    (ref-qualifier :initarg :ref-qualifier
                   :initform nil
                   :reader foreign-method-ref-qualifier)))


### PR DESCRIPTION
This PR goes with [libresect #13](https://github.com/borodust/libresect/pull/13/changes) and [cl-resect #1](https://github.com/borodust/cl-resect/pull/1).

The problem was that I was getting duplicate-definition errors from SBCL (well, it calls them warnings, but then it aborts compilation) on `operator=` methods.  The cause turned out to be that some pairs of these in libtorch were distinguished only by ref qualifiers, which Claw was not capturing.  So then `iffi:defifun` would emit `defun`s for both of them, causing the error.

I have arranged for the qualifier to appear in the `:signed-as` type for the `this` parameter.