### PR TITLE
Add :system-include-type option to use GCC C++ headers

### DIFF
--- a/src/util/util.lisp
+++ b/src/util/util.lisp
@@ -318,7 +318,7 @@
           (setf (uiop:getenv "LC_ALL") lc-all))))))
 
 
-(defun list-system-paths (language triple features)
+(defun list-system-paths (language triple features system-include-type)
   (flet ((%process-paths (paths)
            (mapcar (lambda (path)
                      (uiop:native-namestring (uiop:truename* path)))
@@ -339,8 +339,12 @@
         (unwind-protect
              (%process-paths
               (cond
-                ((not (emptyp (dump-gcc-version clang-name)))
+                ((and (member system-include-type '(:default :clang))
+                      (not (emptyp (dump-gcc-version clang-name))))
                  (dump-include-paths lang clang-name triple))
+                ((eq system-include-type :clang)
+                 (error "system-include-type is :clang, but ~A is not on $PATH"
+                        clang-name))
 
                 ((windows-target-p)
                  (if (not (emptyp (dump-gcc-version (string+ "x86_64-w64-mingw32-" gcc-name))))
@@ -352,9 +356,9 @@
             (setf (uiop:getenv "LC_ALL") lc-all)))))))
 
 
-(defun list-system-include-paths (language triple features)
+(defun list-system-include-paths (language triple features system-include-type)
   (remove-if #'%darwin-framework-path-p
-             (list-system-paths language triple features)))
+             (list-system-paths language triple features system-include-type)))
 
 
 (defun list-default-resource-paths ()
@@ -363,12 +367,12 @@
       (list resource-path))))
 
 
-(defun list-framework-paths (language triple features)
+(defun list-framework-paths (language triple features system-include-type)
   (flet ((cut-darwin-postfix (path)
            (subseq path 0 (- (length path) (length +stupid-darwin-framework-postfix+)))))
     (mapcar #'cut-darwin-postfix
             (remove-if (complement #'%darwin-framework-path-p)
-                       (list-system-paths language triple features)))))
+                       (list-system-paths language triple features system-include-type)))))
 
 (defun dump-gcc-version (&optional (executable "gcc"))
   (handler-case

--- a/src/wrap/wrapper.lisp
+++ b/src/wrap/wrapper.lisp
@@ -42,6 +42,7 @@
   framework-includes
   defines
   intrinsics
+  system-include-type
   system-includes)
 
 
@@ -64,9 +65,13 @@
                          framework-includes
                          defines
                          intrinsics
+			 (system-include-type '(:default))
                          system-includes
                        &allow-other-keys)
       (alist-plist opts)
+    (unless (member (car system-include-type) '(:default :clang :gcc))
+      (error ":system-include-type must be one of (:default :clang :gcc), not ~S"
+	     (car system-include-type)))
     (with-evaluated-variables (language
                                standard)
       (with-evaluated-lists (headers
@@ -92,6 +97,7 @@
                               :headers headers
                               :includes includes
                               :framework-includes framework-includes
+			      :system-include-type (car system-include-type)
                               :system-includes system-includes
                               :defines defines
                               :intrinsics intrinsics
@@ -263,7 +269,8 @@
                       (%parse-opt 'standard target-parse-opts)
                       (%parse-opt 'standard common-parse-opts)))
            (features (target-options-features target-opts))
-           (triple (target-options-triple target-opts)))
+           (triple (target-options-triple target-opts))
+	   (system-include-type (%parse-opt 'system-include-type common-parse-opts)))
       (make-parse-options :include-sources
                           (append
                            (%parse-opt 'include-sources common-parse-opts)
@@ -312,12 +319,14 @@
                           (or (append
                                (%parse-opt 'system-includes target-parse-opts)
                                (%parse-opt 'system-includes common-parse-opts))
-                              (list-system-include-paths language triple features))
+                              (list-system-include-paths language triple features
+							 system-include-type))
                           :framework-includes
                           (or (append
                                (%parse-opt 'framework-includes target-parse-opts)
                                (%parse-opt 'framework-includes common-parse-opts))
-                              (list-framework-paths language triple features))
+                              (list-framework-paths language triple features
+						    system-include-type))
                           :defines
                           (append
                            (%parse-opt 'defines common-parse-opts)


### PR DESCRIPTION
The LibTorch C++ distribution is built against the GCC C++ headers.  So to wrap it, I needed Claw to use those headers instead of Clang's.  (Lots of system types have different mangled names between the two sets of headers — `ostream` is the one I ran into first, but there turned out to be many more.)  I got the effect I wanted by commenting out the first `cond` clause in `claw.util:list-system-paths`, but I thought there should be a `defwrapper` option to do this.  (If I already knew what the correct list of paths was, I could supply it as `:system-includes`, but it's hard to find out what it should be without reading the code that normally generates it.)

So I've added an option to `defwrapper` named `:system-include-type` that can be set to `:clang` or `:gcc`.  It defaults to `:default`, which produces the current behavior (try Clang first, then GCC if Clang is not available); if it's `:clang` and Clang is not available, an error is signalled.