### PR TITLE
Handle inherited constructors

### DIFF
--- a/claw.asd
+++ b/claw.asd
@@ -132,3 +132,13 @@
   :pathname "src/"
   :serial t
   :components ((:file "packages")))
+
+
+(asdf:defsystem :claw/test
+  :description "Test suite for Claw"
+  :license "MIT"
+  :depends-on (:claw)
+  :pathname "test/"
+  :components ((:module "util"
+                :components ((:file "util")))))
+

--- a/src/gen/common/generator/function.lisp
+++ b/src/gen/common/generator/function.lisp
@@ -1,5 +1,6 @@
 (cl:in-package :claw.generator.common)
 
+(alexandria:define-constant this-parameter-entity-name "__claw_this_" :test #'string=)
 
 (defvar *adapt-mode* :c)
 
@@ -210,7 +211,7 @@
                                 (not (claw.spec:foreign-method-static-p entity)))
                            (list* (make-instance
                                    'claw.spec:foreign-parameter
-                                   :name "__claw_this_"
+                                   :name this-parameter-entity-name
                                    :enveloped (make-instance 'claw.spec:foreign-pointer
                                                              :enveloped (claw.spec:foreign-owner entity)))
                                   params)

--- a/src/gen/common/packages.lisp
+++ b/src/gen/common/packages.lisp
@@ -27,6 +27,7 @@
            #:adapted-function-result-type
            #:adapted-function-body
            #:adapted-function-entity
+           #:this-parameter-entity-name
 
            #:adapt-type
 

--- a/src/gen/iffi/cxx/generator/function.lisp
+++ b/src/gen/iffi/cxx/generator/function.lisp
@@ -42,11 +42,19 @@
         for iffi-type = (when from
                           (entity->iffi-type
                            (claw.spec:foreign-enveloped-entity from)))
+        for ref-qual = (and (string= (claw.spec:foreign-entity-name param)
+                                     this-parameter-entity-name)
+                            (let ((rq (claw.spec:foreign-method-ref-qualifier
+                                       (adapted-function-entity adapted-function))))
+                              (and (not (eq rq ':none)) rq)))
         collect `(,name ,cffi-type
                         ,@(unless (and (equal cffi-type cffi-type-no-override)
                                        (or (null iffi-type)
-                                           (equal cffi-type iffi-type)))
-                            (list :signed-as (or iffi-type cffi-type-no-override))))))
+                                           (equal cffi-type iffi-type))
+                                       (null ref-qual))
+                            (list :signed-as
+                                  (append (ensure-cons (or iffi-type cffi-type-no-override))
+                                          (and ref-qual (list ref-qual))))))))
 
 
 (defun generate-function-binding (entity)

--- a/src/resect/prepare.lisp
+++ b/src/resect/prepare.lisp
@@ -135,6 +135,7 @@
                              :ignore-definitions ignore-definitions
                              :ignore-sources ignore-sources)
     (prepare-header implicit uber-path prepared-path)
+    ;; (break "~A" prepared-path)
     (values (list prepared-path)
             (loop for macro being the hash-value of (macros-of implicit)
                   collect macro))))
@@ -176,7 +177,8 @@
 
 
 (defun prepare-new-record-template-instantiations (decl)
-  (unless (or (cffi:null-pointer-p (%resect:declaration-template decl))
+  (unless (or (and (cffi:null-pointer-p (%resect:declaration-template decl))
+                   #+(or) (not (%resect:record-has-inherited-constructor-p decl)))
               (%resect:declaration-partially-specialized-p decl)
               (not (publicp decl))
               (not (template-arguments-public-p decl))

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -125,8 +125,18 @@
                                            intrinsics
                                            &key)
   (declare (ignore header-path includes frameworks language standard target intrinsics))
-  (loop for hook in (reverse *post-parse-hooks*)
-        do (funcall hook)))
+  (let ((n-decls 0))
+    (loop while *post-parse-hooks*
+      do
+      (let ((hooks (reverse *post-parse-hooks*)))
+        (setq *post-parse-hooks* nil)
+        (loop for hook in hooks
+          do (funcall hook)))
+      ;; Prevent bugs from causing infinite loops: if a pass adds no new declarations, exit.
+      (let ((new-n-decls (hash-table-count *declaration-table*)))
+        (unless (> new-n-decls n-decls)
+          (return))
+        (setq n-decls new-n-decls)))))
 
 
 (defmethod inspect-declaration ((this describing-inspector) kind declaration)
@@ -660,18 +670,60 @@
 (defun parse-methods (entity record-decl &key postfix ((:type record-type)))
   (let ((*current-owner* entity)
         (record-type (or record-type (%resect:declaration-type record-decl))))
+    (when (%resect:record-has-inherited-constructor-p record-decl)
+      ;; Libclang doesn't copy down inherited constructors unless they're actually called.
+      ;; And unlike in the template case, compiling an instantiation isn't sufficient to
+      ;; get them to show up.  Libresect has been modified to add them to the decl, but
+      ;; they're not on the type; we need to find the parent class methods and rewrite
+      ;; them for the subclass.
+      (resect:docollection (method-decl (%resect:record-methods record-decl))
+        (when (%resect:method-constructor-p method-decl)
+          (let ((ctor-name (%resect:declaration-name method-decl))
+                (class-name (%resect:declaration-name record-decl)))
+            (unless (string= ctor-name class-name)
+              (let* ((parent-ctor-id (%resect:declaration-id method-decl))
+                     (parent-ctor (find-entity parent-ctor-id)))
+                (if (null parent-ctor)
+                    ;; This is called out of *post-parse-hooks*, which may not be in the
+                    ;; correct order.  If not, we just postpone it again.
+                    (progn
+                      (on-post-parse
+                        (parse-methods entity record-decl :postfix postfix :type record-type))
+                      (return-from parse-methods))
+                  (unless (member (claw.spec:foreign-method-constructor-kind parent-ctor)
+                                  '(:copy :move))
+                    (let* ((child-ctor-id (rewrite-inherited-ctor-id parent-ctor-id ctor-name class-name))
+                           (ctor-namespace (%resect:declaration-namespace method-decl))
+                           (class-namespace (%resect:declaration-namespace record-decl))
+                           ;; Bug: wrong if the child is in a different namespace from the parent.
+                           ;; But it will probably still be unique, which is all we need.
+                           (child-mangled-name
+                             (rewrite-mangled-name (ensure-mangled method-decl) ctor-namespace ctor-name
+                                                   class-namespace class-name))
+                           (class-namespace (claw.spec:foreign-entity-namespace entity))
+                           (child-ctor (claw.spec::copy-foreign-method parent-ctor class-name class-namespace
+                                                                       child-ctor-id child-mangled-name entity)))
+                      (multiple-value-bind (method newp)
+                          (register-entity-instance child-ctor)
+                        (when newp
+                          (setf (gethash child-mangled-name *mangled-table*) method))))))))))))
     (resect:docollection (type-method (%resect:type-methods record-type))
       (let* ((method-prototype (%resect:type-method-prototype type-method))
              (method-decl (%resect:type-method-declaration type-method))
              (mangled-name (ensure-method-mangled-name type-method postfix))
              (pure-method-name (remove-template-argument-string
                                 (%resect:type-method-name type-method)))
+             (pure-record-name (remove-template-argument-string
+                                (foreign-entity-name entity)))
              (constructor-p (%resect:method-constructor-p method-decl))
              (result-type (ensure-const-type-if-needed
                            (%resect:function-proto-result-type method-prototype)
                            (parse-type-by-category
                             (%resect:function-proto-result-type method-prototype)))))
-        (unless (%resect:method-deleted-p method-decl)
+        (unless (or (%resect:method-deleted-p method-decl)
+                    ;; Having pulled down any inherited constructors above, we ignore those
+                    ;; on `record-type', as they are redundant.
+                    (and constructor-p (not (string= pure-method-name pure-record-name))))
           (multiple-value-bind (method newp)
               (register-entity 'foreign-method
                                :id (%resect:type-method-id type-method)
@@ -683,6 +735,7 @@
                                        ((starts-with-subseq "operator" pure-method-name)
                                         :operator)
                                        (t :regular))
+                               :constructor-kind (%resect:type-method-constructor-kind type-method)
                                :source (if (cffi:null-pointer-p method-decl)
                                            (%resect:type-method-source type-method)
                                          (%resect:declaration-source method-decl))
@@ -723,6 +776,35 @@
                                            (%resect:declaration-template-p method-decl)))
             (when newp
               (setf (gethash mangled-name *mangled-table*) method))))))))
+
+(defun rewrite-inherited-ctor-id (id from-class-name to-class-name)
+  ;; This will do the wrong thing if `from-class-name' occurs accidentally in `id',
+  ;; as is possible if it's a single letter, or if it's a substring of some containing
+  ;; namespace name.
+  ;; I don't know what this "c:" prefix is supposed to mean ... seems to always be there.
+  (concatenate 'string (subseq id 0 2)
+               (substitute-substring (subseq id 2) from-class-name to-class-name :count 2)))
+
+(defun rewrite-mangled-name (mangled-name from-namespace from-name to-namespace to-name)
+  (flet ((mangle (namespace name)
+           (format nil "~:{~D~A~}"
+                   (mapcar (lambda (nm) (list (length nm) nm))
+                           (append (ppcre:split "::" namespace) (list name))))))
+    (substitute-substring mangled-name (mangle from-namespace from-name)
+                          (mangle to-namespace to-name))))
+
+(defun substitute-substring (str old-substr new-substr &key count)
+  (let ((start-pos 0))
+    (loop
+      (let ((pos (search old-substr str :start2 start-pos)))
+        (when (null pos)
+          (return))
+        (let ((end (+ pos (length old-substr))))
+          (setq str (concatenate 'string (subseq str 0 pos) new-substr (subseq str end)))
+          (setq start-pos (+ pos (length new-substr))))
+        (when (and count (zerop (decf count)))
+          (return))))
+    str))
 
 
 (defun method-exists-p (decl)

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -666,9 +666,7 @@
              (mangled-name (ensure-method-mangled-name type-method postfix))
              (pure-method-name (remove-template-argument-string
                                 (%resect:type-method-name type-method)))
-             (pure-record-name (remove-template-argument-string
-                                (foreign-entity-name entity)))
-             (constructor-p (string= pure-method-name pure-record-name))
+             (constructor-p (%resect:method-constructor-p method-decl))
              (result-type (ensure-const-type-if-needed
                            (%resect:function-proto-result-type method-prototype)
                            (parse-type-by-category

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -718,6 +718,7 @@
                              :variadic (%resect:function-proto-variadic-p method-prototype)
                              :static (%resect:type-method-static-p type-method)
                              :const (%resect:type-method-const-p type-method)
+                             :ref-qualifier (%resect:method-ref-qualifier method-decl)
                              :template (if (cffi:null-pointer-p method-decl)
                                            nil
                                            (%resect:declaration-template-p method-decl)))

--- a/src/resect/resect.lisp
+++ b/src/resect/resect.lisp
@@ -673,57 +673,58 @@
                            (%resect:function-proto-result-type method-prototype)
                            (parse-type-by-category
                             (%resect:function-proto-result-type method-prototype)))))
-        (multiple-value-bind (method newp)
-            (register-entity 'foreign-method
-                             :id (%resect:type-method-id type-method)
-                             :kind (cond
-                                     (constructor-p
-                                      :constructor)
-                                     ((starts-with #\~ pure-method-name)
-                                      :destructor)
-                                     ((starts-with-subseq "operator" pure-method-name)
-                                      :operator)
-                                     (t :regular))
-                             :source (if (cffi:null-pointer-p method-decl)
-                                         (%resect:type-method-source type-method)
+        (unless (%resect:method-deleted-p method-decl)
+          (multiple-value-bind (method newp)
+              (register-entity 'foreign-method
+                               :id (%resect:type-method-id type-method)
+                               :kind (cond
+                                       (constructor-p
+                                        :constructor)
+                                       ((starts-with #\~ pure-method-name)
+                                        :destructor)
+                                       ((starts-with-subseq "operator" pure-method-name)
+                                        :operator)
+                                       (t :regular))
+                               :source (if (cffi:null-pointer-p method-decl)
+                                           (%resect:type-method-source type-method)
                                          (%resect:declaration-source method-decl))
-                             :name (cond
-                                     (constructor-p
-                                      (string+ pure-method-name
-                                               (extract-template-argument-string
-                                                (%resect:type-name record-type))))
-                                     ((cast-operator-p pure-method-name
-                                                       result-type)
-                                      (string+ "operator "
-                                               (foreign-entity-name result-type)))
+                               :name (cond
+                                       (constructor-p
+                                        (string+ pure-method-name
+                                                 (extract-template-argument-string
+                                                   (%resect:type-name record-type))))
+                                       ((cast-operator-p pure-method-name
+                                                         result-type)
+                                        (string+ "operator "
+                                                 (foreign-entity-name result-type)))
 
-                                     (t (%resect:type-method-name type-method)))
-                             :owner entity
-                             :namespace (unless-empty
-                                         (if (cffi:null-pointer-p method-decl)
-                                             (claw.spec:foreign-entity-namespace entity)
-                                             (%resect:declaration-namespace method-decl)))
-                             :mangled mangled-name
-                             :location (if (cffi:null-pointer-p method-decl)
-                                           (make-instance 'foreign-location
-                                                          :path ""
-                                                          :line 0
-                                                          :column 0)
+                                       (t (%resect:type-method-name type-method)))
+                               :owner entity
+                               :namespace (unless-empty
+                                            (if (cffi:null-pointer-p method-decl)
+                                                (claw.spec:foreign-entity-namespace entity)
+                                              (%resect:declaration-namespace method-decl)))
+                               :mangled mangled-name
+                               :location (if (cffi:null-pointer-p method-decl)
+                                             (make-instance 'foreign-location
+                                                            :path ""
+                                                            :line 0
+                                                            :column 0)
                                            (make-declaration-location method-decl))
-                             :result-type result-type
-                             :parameters (parse-instantiated-method-parameters
-                                          (%resect:function-proto-parameters method-prototype)
-                                          (unless (cffi:null-pointer-p method-decl)
-                                            (%resect:method-parameters method-decl)))
-                             :variadic (%resect:function-proto-variadic-p method-prototype)
-                             :static (%resect:type-method-static-p type-method)
-                             :const (%resect:type-method-const-p type-method)
-                             :ref-qualifier (%resect:method-ref-qualifier method-decl)
-                             :template (if (cffi:null-pointer-p method-decl)
-                                           nil
+                               :result-type result-type
+                               :parameters (parse-instantiated-method-parameters
+                                             (%resect:function-proto-parameters method-prototype)
+                                             (unless (cffi:null-pointer-p method-decl)
+                                               (%resect:method-parameters method-decl)))
+                               :variadic (%resect:function-proto-variadic-p method-prototype)
+                               :static (%resect:type-method-static-p type-method)
+                               :const (%resect:type-method-const-p type-method)
+                               :ref-qualifier (%resect:method-ref-qualifier method-decl)
+                               :template (if (cffi:null-pointer-p method-decl)
+                                             nil
                                            (%resect:declaration-template-p method-decl)))
-          (when newp
-            (setf (gethash mangled-name *mangled-table*) method)))))))
+            (when newp
+              (setf (gethash mangled-name *mangled-table*) method))))))))
 
 
 (defun method-exists-p (decl)

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -80,6 +80,7 @@
            #:foreign-method-static-p
            #:foreign-method-const-p
            #:foreign-method-deleted-p
+           #:foreign-method-ref-qualifier
 
            #:foreign-variable
            #:foreing-variable-type
@@ -477,7 +478,10 @@
             :reader foreign-method-const-p)
    (deleted-p :initarg :deleted
               :initform nil
-              :reader foreign-method-deleted-p)))
+              :reader foreign-method-deleted-p)
+   (ref-qualifier :initarg :ref-qualifier
+                  :initform nil
+                  :reader foreign-method-ref-qualifier)))
 
 
 ;;;

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -77,6 +77,7 @@
 
            #:foreign-method
            #:foreign-method-kind
+           #:foreign-method-constructor-kind
            #:foreign-method-static-p
            #:foreign-method-const-p
            #:foreign-method-deleted-p
@@ -468,8 +469,11 @@
 
 (defclass foreign-method (foreign-function)
   ((kind :initarg :kind
-        :initform :regular
-        :reader foreign-method-kind)
+         :initform :regular
+         :reader foreign-method-kind)
+   (constructor-kind :initarg :constructor-kind
+                     :initform :invalid   ; i.e., not a constructor
+                     :reader foreign-method-constructor-kind)
    (static-p :initarg :static
              :initform nil
              :reader foreign-method-static-p)
@@ -479,6 +483,30 @@
    (ref-qualifier :initarg :ref-qualifier
                   :initform nil
                   :reader foreign-method-ref-qualifier)))
+
+(defun copy-foreign-method (method new-name new-namespace new-id new-mangled-name new-owner)
+  (check-type method foreign-method)
+  (make-instance 'foreign-method
+                 :location (foreign-entity-location method)
+                 :id new-id
+                 :name new-name
+                 :namespace new-namespace
+                 :mangled new-mangled-name
+                 :template (foreign-entity-template-p method)
+                 :entity-parameters (foreign-entity-parameters method)
+                 :entity-arguments (foreign-entity-arguments method)
+                 :owner new-owner
+                 :source (foreign-entity-source method)
+                 :result-type (foreign-function-result-type method)
+                 :parameters (foreign-function-parameters method)
+                 :variadic (foreign-function-variadic-p method)
+                 :storage-class (foreign-function-storage-class method)
+                 :inlined (foreign-function-inlined-p method)
+                 :kind (foreign-method-kind method)
+                 :constructor-kind (foreign-method-constructor-kind method)
+                 :static (foreign-method-static-p method)
+                 :const (foreign-method-const-p method)
+                 :ref-qualifier (foreign-method-ref-qualifier method)))
 
 
 ;;;

--- a/src/spec/entity.lisp
+++ b/src/spec/entity.lisp
@@ -476,9 +476,6 @@
    (const-p :initarg :const
              :initform nil
             :reader foreign-method-const-p)
-   (deleted-p :initarg :deleted
-              :initform nil
-              :reader foreign-method-deleted-p)
    (ref-qualifier :initarg :ref-qualifier
                   :initform nil
                   :reader foreign-method-ref-qualifier)))

--- a/src/util/util.lisp
+++ b/src/util/util.lisp
@@ -113,8 +113,8 @@
                         (return (values (nreverse result) len))
                    when (char= (aref name idx) #\,)
                      do (unless (= last-end idx)
-                          (push (substring-trim name last-end idx) result)
-                          (setf last-end (1+ idx)))
+                          (push (substring-trim name last-end idx) result))
+                        (setf last-end (1+ idx))
                    when (and (char= (aref name idx) #\>)
                              (not (%weird-char-p (1+ idx))))
                      do (unless (= last-end idx)
@@ -122,8 +122,8 @@
                         (return (values (nreverse result) (1+ idx)))
                    when (and (char= (aref name idx) #\<)
                              (not (%weird-char-p (1+ idx))))
-                     do (when (> (- idx pos) 1)
-                          (push (substring-trim name pos idx) result))
+                     do (unless (= last-end idx)
+                          (push (substring-trim name last-end idx) result))
                         (multiple-value-bind (groups end)
                             (%extract (1+ idx))
                           (push groups result)
@@ -133,14 +133,22 @@
 
 
 (defun join-groups-into-template-name (groups)
-  (format nil "~{~A~}"
-          (loop for (group next) on groups
-                collect (cond
-                          ((listp group)
-                           (format nil "<~A>" (join-groups-into-template-name group)))
-                          ((listp next) group)
-                          (t (format nil "~A," group))))))
-
+  (labels ((join-type (groups str)
+             (if (null groups)
+                 str
+               (let ((str (format nil "~@[~A,~]~A" str (car groups))))
+                 (if (listp (cadr groups))
+                     (join-args (cdr groups) str)
+                   (join-type (cdr groups) str)))))
+           (join-args (groups str)
+             (cond ((null groups)
+                    str)
+                   ((listp (car groups))
+                    (join-args (cdr groups)
+                               (format nil "~@[~A~]<~A>" str (join-type (car groups) nil))))
+                   (t
+                    (join-type groups str)))))
+    (join-args groups nil)))
 
 (defun remove-template-argument-string (name)
   (let* ((groups (split-template-name-into-groups name))

--- a/test/util/util.lisp
+++ b/test/util/util.lisp
@@ -1,0 +1,36 @@
+(in-package :claw.util)
+
+
+(defun test-template-handling ()
+  (macrolet ((test (form)
+               `(unless ,form
+                  (cerror "proceed" "Test failed: ~S" ',form))))
+    (test (equal (split-template-name-into-groups "A")
+                 '("A")))
+    (test (equal (split-template-name-into-groups "A<int>")
+                 '("A" ("int"))))
+    (test (equal (split-template-name-into-groups "A<B<int>, C>")
+                 '("A" ("B" ("int") "C"))))
+    (test (equal (split-template-name-into-groups "A<B, C<int>>")
+                 '("A" ("B" "C" ("int")))))
+    (test (equal (split-template-name-into-groups "A<B, C<int>, D>")
+                 '("A" ("B" "C" ("int") "D"))))
+
+    ;; Previous result: ""
+    (test (equal (remove-template-argument-string "A<int>")
+                 "A"))
+    ;; Previous result: "<1,1, B<int>, C>"
+    (test (equal (extract-template-argument-string "A<1, B<int>, C>")
+                 "<1, B<int>, C>"))
+
+    (test (equal (extract-template-argument-string "A")
+                 nil))
+    (test (equal (extract-template-argument-string "A<int>")
+                 "<int>"))
+    (test (equal (extract-template-argument-string "A<B<int>, C>")
+                 "<B<int>, C>"))
+    (test (equal (extract-template-argument-string "A<B, C<int>>")
+                 "<B, C<int>>"))
+    (test (equal (extract-template-argument-string "A<B, C<int>, D>")
+                 "<B, C<int>, D>"))
+    "Passed"))


### PR DESCRIPTION
This PR depends on #20, and should not be merged until that one is.  It also depends on PRs with the same title for libresect and cl-resect.

C++'s constructor-inheritance feature is just hell to deal with.  Libclang is not as much help as it should be, because inherited constructors do not appear on the subclass's `CXType` unless they're referenced.  (I tried declaring an instance of the subclass, as is done for templates in `prepared_header.h`, but that didn't cause the constructors to show up.)  It is possible to find all the inherited constructors by walking the decl, however, and I figured out how to do this.

This allows me to revert the changes I had made to the LibTorch headers that edited out all uses of constructor inheritance.

The generated adapter compiles and loads, and I have spot-checked the differences between the previous results (with constructor inheritance hand-edited out) and the new ones, and they look reasonable.

I ran into a couple more minor bugs in `claw.util:split-template-name-into-groups` and `claw.util:join-groups-into-template-name`; I made minor changes to the former and rewrote the latter.  I added a few tests in `test/util/util.lisp`; look there to see what was wrong.